### PR TITLE
fix: Fixed errors in consumer.cpp

### DIFF
--- a/consumer/src/consumer.cpp
+++ b/consumer/src/consumer.cpp
@@ -45,7 +45,7 @@ namespace pact_consumer {
         bool callback_result = callback(&mockServer);
         bool mock_server_result = mock_server_matched(mockServer.get_port());
         if (callback_result && mock_server_result) {
-          auto write_result = write_pact_file(mockServer.get_port(), this->pact_directory.data());
+          auto write_result = write_pact_file(mockServer.get_port(), this->pact_directory.data(), false);
           switch (write_result) {
             case 1:
               result.add_state(TestResultState::PactFileError, "A general panic was caught");
@@ -150,7 +150,7 @@ namespace pact_consumer {
     std::vector<char> buffer(size);
     if (file.read(buffer.data(), size)) {
       pact_mock_server_ffi::with_binary_file(this->interaction, pact_mock_server_ffi::InteractionPart::Request, content_type.data(), 
-        buffer.data(), size);
+        (const uint8_t*)buffer.data(), size);
       return *this;
     } else {
       throw std::string("Could not read file contents: ") + example_file.string();
@@ -201,7 +201,7 @@ namespace pact_consumer {
     std::vector<char> buffer(size);
     if (file.read(buffer.data(), size)) {
       pact_mock_server_ffi::with_binary_file(this->interaction, pact_mock_server_ffi::InteractionPart::Response, content_type.data(), 
-        buffer.data(), size);
+        (const uint8_t*)buffer.data(), size);
       return *this;
     } else {
       throw std::string("Could not read file contents: ") + example_file.string();


### PR DESCRIPTION
### Description

We can not compile the consumer.cpp mainly because of two errors:
1. too few arguments to function ‘int32_t pact_mock_server_ffi::write_pact_file(int32_t, const char*, bool)’
2. invalid conversion from ‘char*’ to ‘const uint8_t*’ while calling `pact_mock_server_ffi::with_binary_file()`

The first error can be resolved by including the third argument in the `pact_mock_server_ffi::write_pact_file` function call. And the second error can be resolved by casting the `buffer.data()` to `const uint8_t*` while calling the `pact_mock_server_ffi::with_binary_file` function from `consumer.cpp`


#### Resolving error 1
The error is as follows:
```
error: too few arguments to function ‘int32_t pact_mock_server_ffi::write_pact_file(int32_t, const char*, bool)’
   48 | _pact_file(mockServer.get_port(), this->pact_directory.data());
```
   
   Here the last boolean argument determines if the file should be overrite or not. The declaration in the `pact_mock_server_ffi.h` for this function is as follows:
   `int32_t write_pact_file(int32_t mock_server_port, const char *directory, bool overwrite);`
   
 In this PR, I have set the overwrite to false.

   
#### Resolving error 2
The error is as follows:
```
error: invalid conversion from ‘char*’ to ‘const uint8_t*’ {aka ‘const unsigned char*’} [-fpermissive]
  153 |         buffer.data(), size);
      |         ~~~~~~~~~~~^~
      |                    |
      |                    char*
```

This error arrise because the declaration of the `with_binary_file()` method in the `pact_mock_server_ffi_h` is as follows:
```
bool with_binary_file(InteractionHandle interaction,
                      InteractionPart part,
                      const char *content_type,
                      const uint8_t *body,
                      size_t size);
```
And while passing the argument `body`, a `char*` data is passed. And the solution is parsing the argument to `const uint8_t*` while calling from `consumer.cpp`